### PR TITLE
[#2] 🔐 Auth & User Domain 구현 (Repository, UseCase)

### DIFF
--- a/beilsang/Projects/Domain/AuthDomain/Derived/InfoPlists/AuthDomain-Info.plist
+++ b/beilsang/Projects/Domain/AuthDomain/Derived/InfoPlists/AuthDomain-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/beilsang/Projects/Domain/AuthDomain/Project.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Project.swift
@@ -1,0 +1,32 @@
+import ProjectDescription
+
+let project = Project(
+    name: "AuthDomain",
+    settings: .settings(
+        base: [
+            "SWIFT_VERSION": "5.9"
+        ],
+        configurations: [
+            .debug(name: "dev"),
+            .debug(name: "stag"),
+            .release(name: "prod"),
+        ]
+    ),
+    targets: [
+        .target(
+            name: "AuthDomain",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.beilsang.AuthDomain",
+            deploymentTargets: .iOS("18.5"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            dependencies: [
+                .project(target: "ModelsShared", path: "../../Shared/Models"),
+                .project(target: "NetworkCore", path: "../../Core/NetworkCore"),
+                .project(target: "StorageCore", path: "../../Core/StorageCore"),
+                .external(name: "Alamofire")
+            ]
+        )
+    ]
+)

--- a/beilsang/Projects/Domain/AuthDomain/Sources/Entities/AuthError.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/Entities/AuthError.swift
@@ -1,0 +1,76 @@
+//
+//  AuthError.swift
+//  ModelsShared
+//
+//  Created by Seyoung Park on 9/1/25.
+//
+
+import Foundation
+import StorageCore
+
+/// 인증 관련 에러 정의 (로그인, 회원가입, 토큰 관리 등)
+public enum AuthError: Error, Equatable, Sendable {
+    // 로그인 관련
+    case invalidCredentials       // 로그인 정보 불일치
+    
+    // 회원가입 관련
+    case signUpFailed(String)     // 회원가입 실패
+    
+    // 토큰 관련
+    case tokenExpired             // 토큰 만료
+    
+    // 외부 인증
+    case kakaoError(String)       // 카카오 SDK 관련 에러
+    case appleError(String)       // 애플 로그인 관련 에러
+    
+    // HTTP & 네트워크
+    case httpError(statusCode: Int)  // HTTP 상태 코드 에러
+    case networkError             // 네트워크 오류
+    case serverError(String)      // 서버 에러 (메시지 포함)
+    
+    // 데이터 처리
+    case decodingError(String)    // JSON 디코딩 실패
+    case encodingError(String)    // JSON 인코딩 실패
+    
+    // 공통
+    case unknownError(String)     // 알 수 없는 에러
+    
+    // Equatable 구현
+    public static func == (lhs: AuthError, rhs: AuthError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidCredentials, .invalidCredentials),
+             (.tokenExpired, .tokenExpired),
+             (.networkError, .networkError):
+            return true
+        case (.signUpFailed(let a), .signUpFailed(let b)),
+             (.kakaoError(let a), .kakaoError(let b)),
+             (.appleError(let a), .appleError(let b)),
+             (.serverError(let a), .serverError(let b)),
+             (.decodingError(let a), .decodingError(let b)),
+             (.encodingError(let a), .encodingError(let b)),
+             (.unknownError(let a), .unknownError(let b)):
+            return a == b
+        case (.httpError(let a), .httpError(let b)):
+            return a == b
+        default:
+            return false
+        }
+    }
+}
+
+public extension AuthError {
+    static func fromKeychainError(_ error: KeychainError) -> AuthError {
+        switch error {
+        case .encodingFailed(let message):
+            return .encodingError(message)
+        case .decodingFailed(let message):
+            return .decodingError(message)
+        case .keychainSaveFailed(let status):
+            return .serverError("토큰 저장에 실패했습니다. (status: \(status))")
+        case .keychainLoadFailed(let status):
+            return .serverError("토큰 조회에 실패했습니다. (status: \(status))")
+        case .keychainDeleteFailed(let status):
+            return .serverError("토큰 삭제에 실패했습니다. (status: \(status))")
+        }
+    }
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/Entities/AuthState.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/Entities/AuthState.swift
@@ -1,0 +1,19 @@
+//
+//  AuthState.swift
+//  ModelsShared
+//
+//  Created by Seyoung Park on 8/31/25.
+//
+
+import Foundation
+
+/// 인증 상태 (로그인, 회원가입 등 인증 플로우 전반)
+public enum AuthState: Equatable {
+    case idle                         // 대기 중
+    case loading                      // 처리 중 (로그인, 회원가입 등)
+    case authenticated                // 인증 완료 (기존 회원)
+    case needsSignUp                  // 인증 완료 but 회원가입 필요 (신규 회원)
+    case unauthenticated              // 미인증
+    case tokenExpired                 // 토큰 만료
+    case error(AuthError)             // 에러
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/Entities/SignUpData.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/Entities/SignUpData.swift
@@ -1,0 +1,39 @@
+//
+//  SignUpData.swift
+//  AuthDomain
+//
+//  Created by Seyoung Park on 8/31/25.
+//
+
+import Foundation
+import ModelsShared
+import UtilityShared
+
+/// Domain model for managing UI input values in the sign-up flow,
+/// used until conversion to `SignUpRequest` for server transmission
+///
+/// - ViewModel binds user input values to populate this object
+/// - Sign-up UseCase converts this model to `SignUpRequest` for server communication
+public struct SignUpData: Equatable {
+    public var accessToken: String = ""
+    public var keyword: Keyword? = nil
+    public var motto: Motto? = nil
+    public var userInfo: UserInfo = .init()
+    public var referralInfo: ReferralInfo = .init()
+
+    public init() {}
+
+    public func toRequest() -> SignUpRequest {
+        SignUpRequest(
+            accessToken: accessToken,
+            gender: userInfo.gender ?? "기타",
+            nickName: userInfo.nickname,
+            birth: userInfo.birthDate?.toServerFormat() ?? "",
+            address: userInfo.address,
+            keyword: keyword?.rawValue ?? "",
+            discoveredPath: referralInfo.source ?? "",
+            resolution: motto?.rawValue ?? "",
+            recommendNickname: referralInfo.recommender
+        )
+    }
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/Repositories/AuthRepository.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/Repositories/AuthRepository.swift
@@ -1,0 +1,439 @@
+//
+//  AuthRepository.swift
+//  AuthData
+//
+//  Created by Park Seyoung on 8/28/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+import Alamofire
+
+public final class AuthRepository: AuthRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+    
+    public init(baseURL: String) {
+        self.apiClient = APIClient(baseURL: baseURL)
+    }
+    
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Nickname Check
+    public func checkNickname(_ nickname: String) -> AnyPublisher<Bool, AuthError> {
+        guard nickname.isEmpty == false else {
+            return Fail(error: .serverError("닉네임이 올바르지 않습니다."))
+                .eraseToAnyPublisher()
+        }
+        
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔍 Using mock nickname check: \(nickname)")
+            #endif
+            let isAvailable = !nickname.lowercased().contains("중복") && !nickname.lowercased().contains("duplicate")
+            return Just(isAvailable)
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🔍 Checking nickname: \(nickname)")
+        #endif
+        
+        guard let encoded = nickname.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return Fail(error: .serverError("닉네임 인코딩 실패"))
+                .eraseToAnyPublisher()
+        }
+        
+        let path = "api/oauth/nickname?nickname=\(encoded)"
+        typealias NicknameResponse = APIResponse<String>
+        let publisher: AnyPublisher<NicknameResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> Bool in
+                #if DEBUG
+                print("🔍 Nickname check response - statusCode: \(response.statusCode), code: \(response.code), message: \(response.message)")
+                #endif
+                
+                // 200: 유효한 닉네임, 400: 유효하지 않은 닉네임
+                switch response.statusCode {
+                case 200:
+                    #if DEBUG
+                    print("✅ Nickname is available")
+                    #endif
+                    return true
+                case 400:
+                    #if DEBUG
+                    print("❌ Nickname is invalid or duplicate")
+                    #endif
+                    return false
+                default:
+                    throw AuthError.serverError(response.message)
+                }
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Kakao Login
+    public func loginWithKakao(request: KakaoLoginRequest) -> AnyPublisher<(KeychainToken, Bool), AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🟡 Using mock Kakao login")
+            #endif
+            let token = KeychainToken(
+                accessToken: "mock_kakao_access_token_\(UUID().uuidString)",
+                refreshToken: "mock_kakao_refresh_token_\(UUID().uuidString)",
+                expiresIn: 3600
+            )
+            // Mock에서는 항상 신규 회원으로 가정
+            return Just((token, false))
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🟡 Kakao idToken: \(request.idToken.prefix(20))...")
+        if let jsonData = try? JSONEncoder().encode(request),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            print("🟡 Request body: \(jsonString)")
+        }
+        #endif
+        
+        let publisher: AnyPublisher<KakaoLoginResponse, APIClientError> = apiClient.request(
+            path: "api/oauth/login/kakao",
+            method: .post,
+            body: request,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> (KeychainToken, Bool) in
+                guard let data = response.data else {
+                    throw AuthError.serverError(response.message)
+                }
+                
+                #if DEBUG
+                print("✅ 카카오 로그인 서버 응답 성공:")
+                print("   accessToken: \(data.accessToken.prefix(20))...")
+                print("   refreshToken: \(data.refreshToken.prefix(20))...")
+                print("   isExistMember: \(data.isExistMember)")
+                #endif
+                
+                let token = KeychainToken(
+                    accessToken: data.accessToken,
+                    refreshToken: data.refreshToken
+                )
+                
+                return (token, data.isExistMember)
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Apple Login
+    public func loginWithApple(request: AppleLoginRequest) -> AnyPublisher<(KeychainToken, Bool), AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🍎 Using mock Apple login")
+            #endif
+            let token = KeychainToken(
+                accessToken: "mock_apple_access_token_\(UUID().uuidString)",
+                refreshToken: "mock_apple_refresh_token_\(UUID().uuidString)",
+                expiresIn: 3600
+            )
+            return Just((token, true))
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🍎 identityToken: \(request.identityToken)")
+        if let jsonData = try? JSONEncoder().encode(request),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            print("🍎 Request body: \(jsonString)")
+        }
+        #endif
+        
+        let publisher: AnyPublisher<AppleLoginResponse, APIClientError> = apiClient.request(
+            path: "api/oauth/login/apple",
+            method: .post,
+            body: request,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> (KeychainToken, Bool) in
+                guard response.isSuccess else {
+                    throw AuthError.appleError(response.message)
+                }
+                guard let result = response.data else {
+                    throw AuthError.decodingError("토큰 정보가 비어 있습니다.")
+                }
+                
+                #if DEBUG
+                print("✅ 애플 로그인 서버 응답 성공:")
+                print("   accessToken: \(result.accessToken.prefix(20))...")
+                print("   refreshToken: \(result.refreshToken.prefix(20))...")
+                print("   isExistMember: \(result.isExistMember)")
+                #endif
+                
+                let token = KeychainToken(
+                    accessToken: result.accessToken,
+                    refreshToken: result.refreshToken
+                )
+                
+                return (token, result.isExistMember)
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Sign Up
+    public func signUp(request: SignUpRequest) -> AnyPublisher<KeychainToken, AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📝 Using mock sign up")
+            #endif
+            let token = KeychainToken(
+                accessToken: "mock_signup_access_token_\(UUID().uuidString)",
+                refreshToken: "mock_signup_refresh_token_\(UUID().uuidString)",
+                expiresIn: 3600
+            )
+            return Just(token)
+                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        return Future { promise in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                let token = KeychainToken(
+                    accessToken: "mock_access_token",
+                    refreshToken: "mock_refresh_token"
+                )
+                promise(.success(token))
+            }
+        }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Sign Up Simplified (약관 동의만) - Mock Only
+    public func signUpSimplified(request: SignUpSimplifiedRequest) -> AnyPublisher<KeychainToken, AuthError> {
+        // Mock 데이터로만 동작 (API 연결 없음)
+        #if DEBUG
+        print("📝 Mock simplified sign up (marketing: \(request.marketingAgreed))")
+        #endif
+        
+        let token = KeychainToken(
+            accessToken: "mock_signup_simplified_access_token_\(UUID().uuidString)",
+            refreshToken: "mock_signup_simplified_refresh_token_\(UUID().uuidString)",
+            expiresIn: 3600
+        )
+        
+        return Just(token)
+            .delay(for: .milliseconds(800), scheduler: DispatchQueue.main)
+            .setFailureType(to: AuthError.self)
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Logout Kakao
+    public func logoutKakao() -> AnyPublisher<Void, AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🚪 Using mock Kakao logout")
+            #endif
+            return Just(())
+                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🚪 Logging out from Kakao account...")
+        #endif
+        
+        // 로그아웃은 인증이 필요하므로 interceptor를 사용 (APIClient의 session에 이미 설정됨)
+        let publisher: AnyPublisher<LogoutKakaoResponse, APIClientError> = apiClient.request(
+            path: "api/oauth/logout/kakao",
+            method: .post,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> Void in
+                #if DEBUG
+                print("🔄 로그아웃 응답: statusCode=\(response.statusCode), code=\(response.code), message=\(response.message)")
+                #endif
+                
+                // statusCode가 200이면 성공
+                guard response.statusCode == 200 else {
+                    throw AuthError.serverError(response.message)
+                }
+                
+                #if DEBUG
+                print("✅ 카카오 로그아웃 성공: \(response.message)")
+                #endif
+                
+                return ()
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Revoke Kakao
+    public func revokeKakao() -> AnyPublisher<Void, AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🚪 Using mock Kakao revoke")
+            #endif
+            return Just(())
+                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🚪 Revoking Kakao account...")
+        #endif
+        
+        // 탈퇴는 인증이 필요하므로 interceptor를 사용 (APIClient의 session에 이미 설정됨)
+        // interceptor를 nil로 전달하면 Session의 기본 interceptor가 사용됨
+        let publisher: AnyPublisher<RevokeKakaoResponse, APIClientError> = apiClient.request(
+            path: "api/oauth/unlink/kakao",
+            method: .post,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> Void in
+                #if DEBUG
+                print("🔄 탈퇴 응답: statusCode=\(response.statusCode), code=\(response.code), message=\(response.message)")
+                #endif
+                
+                // statusCode가 200이면 성공
+                guard response.statusCode == 200 else {
+                    throw AuthError.serverError(response.message)
+                }
+                
+                #if DEBUG
+                print("✅ 카카오 탈퇴 성공: \(response.message)")
+                #endif
+                
+                return ()
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Revoke Apple
+    public func revokeApple() -> AnyPublisher<Void, AuthError> {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🚪 Using mock Apple revoke")
+            #endif
+            return Just(())
+                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                .setFailureType(to: AuthError.self)
+                .eraseToAnyPublisher()
+        }
+        
+        #if DEBUG
+        print("🚪 Revoking Apple account...")
+        #endif
+        
+        // 애플 탈퇴 API 호출 (응답 data는 String 타입)
+        let publisher: AnyPublisher<RevokeAppleResponse, APIClientError> = apiClient.request(
+            path: "api/oauth/unlink/apple",
+            method: .post,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return publisher
+            .mapError(AuthRepository.mapAPIError(_:))
+            .tryMap { response -> Void in
+                #if DEBUG
+                print("🔄 탈퇴 응답: statusCode=\(response.statusCode), code=\(response.code), message=\(response.message)")
+                if let data = response.data {
+                    print("   data: \(data)")
+                }
+                #endif
+                
+                // statusCode가 200이면 성공 (애플은 statusCode 0도 성공일 수 있음)
+                guard response.statusCode == 200 || response.statusCode == 0 else {
+                    throw AuthError.serverError(response.message)
+                }
+                
+                #if DEBUG
+                print("✅ 애플 탈퇴 성공: \(response.message)")
+                #endif
+                
+                return ()
+            }
+            .mapError { $0 as? AuthError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Helpers
+private extension AuthRepository {
+    struct APIErrorResponse: Decodable {
+        let statusCode: Int?
+        let code: String?
+        let message: String
+    }
+    
+    static func mapAPIError(_ error: APIClientError) -> AuthError {
+        switch error {
+        case .invalidURL:
+            return .networkError
+        case .http(let statusCode, let data):
+            if let authError = parseAPIError(data: data) {
+                return authError
+            }
+            return .httpError(statusCode: statusCode)
+        case .decoding(let message, let data):
+            if let authError = parseAPIError(data: data) {
+                return authError
+            }
+            return .decodingError(message)
+        case .network:
+            return .networkError
+        }
+    }
+    
+    static func parseAPIError(data: Data?) -> AuthError? {
+        guard
+            let data,
+            let response = try? JSONDecoder().decode(APIErrorResponse.self, from: data)
+        else {
+            return nil
+        }
+        
+        if response.message.isEmpty == false {
+            return .serverError(response.message)
+        }
+        return nil
+    }
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/Repositories/AuthRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/Repositories/AuthRepositoryProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  AuthRepositoryProtocol.swift
+//  AuthDomain
+//
+//  Created by Park Seyoung on 8/28/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+
+// MARK: - Repository
+public protocol AuthRepositoryProtocol {
+    func checkNickname(_ nickname: String) -> AnyPublisher<Bool, AuthError>
+    func loginWithKakao(request: KakaoLoginRequest) -> AnyPublisher<(KeychainToken, Bool), AuthError>
+    func loginWithApple(request: AppleLoginRequest) -> AnyPublisher<(KeychainToken, Bool), AuthError>
+    func signUp(request: SignUpRequest) -> AnyPublisher<KeychainToken, AuthError>
+    func signUpSimplified(request: SignUpSimplifiedRequest) -> AnyPublisher<KeychainToken, AuthError>
+    func logoutKakao() -> AnyPublisher<Void, AuthError>
+    func revokeKakao() -> AnyPublisher<Void, AuthError>
+    func revokeApple() -> AnyPublisher<Void, AuthError>
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/AppleLoginUseCase.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/AppleLoginUseCase.swift
@@ -1,0 +1,51 @@
+//
+//  AppleLoginUseCase.swift
+//  AuthDomain
+//
+//  Created by Seyoung Park on 10/07/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import StorageCore
+
+public protocol AppleLoginUseCaseProtocol {
+    func login(request: AppleLoginRequest) -> AnyPublisher<AuthState, Never>
+}
+
+public final class AppleLoginUseCase: AppleLoginUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+    private let tokenStorage: KeychainTokenStorageProtocol
+
+    public init(repository: AuthRepositoryProtocol, tokenStorage: KeychainTokenStorageProtocol) {
+        self.repository = repository
+        self.tokenStorage = tokenStorage
+    }
+
+    public func login(request: AppleLoginRequest) -> AnyPublisher<AuthState, Never> {
+        return repository.loginWithApple(request: request)
+            .flatMap { [tokenStorage] token, isExistMember -> AnyPublisher<AuthState, AuthError> in
+                // 애플 로그인 provider 정보 추가
+                let tokenWithProvider = KeychainToken(
+                    accessToken: token.accessToken,
+                    refreshToken: token.refreshToken,
+                    tokenType: token.tokenType,
+                    expiresIn: token.expiresIn,
+                    createdAt: token.createdAt,
+                    provider: .apple
+                )
+                return tokenStorage.saveToken(tokenWithProvider)
+                    .map { _ in
+                        // isExistMember가 false면 신규 회원 (회원가입 필요)
+                        // isExistMember가 true면 기존 회원 (인증 완료)
+                        isExistMember ? AuthState.authenticated : AuthState.needsSignUp
+                    }
+                    .mapError { AuthError.fromKeychainError($0) }
+                    .eraseToAnyPublisher()
+            }
+            .catch { error in Just(AuthState.error(error)) }
+            .prepend(.loading)
+            .eraseToAnyPublisher()
+    }
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/KakaoLoginUseCase.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/KakaoLoginUseCase.swift
@@ -1,0 +1,51 @@
+//
+//  KakaoLoginUseCase.swift
+//  AuthDomain
+//
+//  Created by Seyoung Park on 10/07/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import StorageCore
+
+public protocol KakaoLoginUseCaseProtocol {
+    func login(request: KakaoLoginRequest) -> AnyPublisher<AuthState, Never>
+}
+
+public final class KakaoLoginUseCase: KakaoLoginUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+    private let tokenStorage: KeychainTokenStorageProtocol
+
+    public init(repository: AuthRepositoryProtocol, tokenStorage: KeychainTokenStorageProtocol) {
+        self.repository = repository
+        self.tokenStorage = tokenStorage
+    }
+
+    public func login(request: KakaoLoginRequest) -> AnyPublisher<AuthState, Never> {
+        return repository.loginWithKakao(request: request)
+            .flatMap { [tokenStorage] token, isExistMember -> AnyPublisher<AuthState, AuthError> in
+                // 카카오 로그인 provider 정보 추가
+                let tokenWithProvider = KeychainToken(
+                    accessToken: token.accessToken,
+                    refreshToken: token.refreshToken,
+                    tokenType: token.tokenType,
+                    expiresIn: token.expiresIn,
+                    createdAt: token.createdAt,
+                    provider: .kakao
+                )
+                return tokenStorage.saveToken(tokenWithProvider)
+                    .map { _ in
+                        // isExistMember가 false면 신규 회원 (회원가입 필요)
+                        // isExistMember가 true면 기존 회원 (인증 완료)
+                        isExistMember ? AuthState.authenticated : AuthState.needsSignUp
+                    }
+                    .mapError { AuthError.fromKeychainError($0) }
+                    .eraseToAnyPublisher()
+            }
+            .catch { error in Just(AuthState.error(error)) }
+            .prepend(.loading)
+            .eraseToAnyPublisher()
+    }
+}

--- a/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/LogoutUseCase.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/LogoutUseCase.swift
@@ -1,0 +1,88 @@
+//
+//  LogoutUseCase.swift
+//  AuthDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import StorageCore
+
+public protocol LogoutUseCaseProtocol {
+    func logout() -> AnyPublisher<Void, AuthError>
+}
+
+public final class LogoutUseCase: LogoutUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+    private let tokenStorage: KeychainTokenStorageProtocol
+
+    public init(repository: AuthRepositoryProtocol, tokenStorage: KeychainTokenStorageProtocol) {
+        self.repository = repository
+        self.tokenStorage = tokenStorage
+    }
+
+    public func logout() -> AnyPublisher<Void, AuthError> {
+        // 저장된 토큰에서 provider 정보 확인
+        return tokenStorage.getToken()
+            .mapError { AuthError.fromKeychainError($0) }
+            .flatMap { [weak self] token -> AnyPublisher<Void, AuthError> in
+                guard let self = self else {
+                    return Fail(error: AuthError.unknownError("LogoutUseCase deallocated"))
+                        .eraseToAnyPublisher()
+                }
+                
+                // provider가 있으면 해당 로그아웃 API 호출, 없으면 바로 성공 처리
+                guard let token = token, let provider = token.provider else {
+                    #if DEBUG
+                    print("⚠️ No provider found, skipping logout API call")
+                    #endif
+                    // provider가 없으면 바로 성공 처리 (하위 호환성)
+                    return Just(())
+                        .setFailureType(to: AuthError.self)
+                        .eraseToAnyPublisher()
+                }
+                
+                #if DEBUG
+                print("🚪 Logging out with provider: \(provider.rawValue)")
+                #endif
+                
+                // 저장된 provider에 따라 적절한 로그아웃 API 호출
+                switch provider {
+                case .kakao:
+                    // 카카오는 서버 로그아웃 API 호출
+                    return self.repository.logoutKakao()
+                case .apple:
+                    // 애플은 클라이언트에서만 처리 (서버 API 없음)
+                    #if DEBUG
+                    print("🍎 Apple logout: 클라이언트에서만 처리 (토큰 삭제)")
+                    #endif
+                    return Just(())
+                        .setFailureType(to: AuthError.self)
+                        .eraseToAnyPublisher()
+                }
+            }
+            .catch { error -> AnyPublisher<Void, AuthError> in
+                // 로그아웃 API 실패해도 토큰은 삭제하고 진행 (클라이언트 토큰 삭제는 필수)
+                #if DEBUG
+                print("❌ 로그아웃 API 실패: \(error), but continuing with token deletion")
+                #endif
+                return Just(())
+                    .setFailureType(to: AuthError.self)
+                    .eraseToAnyPublisher()
+            }
+            .flatMap { [weak self] _ -> AnyPublisher<Void, AuthError> in
+                guard let self = self else {
+                    return Fail(error: AuthError.unknownError("LogoutUseCase deallocated"))
+                        .eraseToAnyPublisher()
+                }
+                // API 성공/실패와 관계없이 토큰 삭제 진행
+                return self.tokenStorage.deleteToken()
+                    .mapError { AuthError.fromKeychainError($0) }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+}
+

--- a/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/RevokeUseCase.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/RevokeUseCase.swift
@@ -1,0 +1,71 @@
+//
+//  RevokeUseCase.swift
+//  AuthDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import StorageCore
+
+public protocol RevokeUseCaseProtocol {
+    func revoke() -> AnyPublisher<Void, AuthError>
+}
+
+public final class RevokeUseCase: RevokeUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+    private let tokenStorage: KeychainTokenStorageProtocol
+
+    public init(repository: AuthRepositoryProtocol, tokenStorage: KeychainTokenStorageProtocol) {
+        self.repository = repository
+        self.tokenStorage = tokenStorage
+    }
+
+    public func revoke() -> AnyPublisher<Void, AuthError> {
+        // 저장된 토큰에서 provider 정보 확인
+        return tokenStorage.getToken()
+            .mapError { AuthError.fromKeychainError($0) }
+            .flatMap { [weak self] token -> AnyPublisher<Void, AuthError> in
+                guard let self = self else {
+                    return Fail(error: AuthError.unknownError("RevokeUseCase deallocated"))
+                        .eraseToAnyPublisher()
+                }
+                
+                guard let token = token else {
+                    #if DEBUG
+                    print("⚠️ No token found, cannot determine provider")
+                    #endif
+                    return Fail(error: AuthError.unknownError("토큰을 찾을 수 없습니다"))
+                        .eraseToAnyPublisher()
+                }
+                
+                // 저장된 provider에 따라 적절한 탈퇴 API 호출
+                let provider = token.provider ?? .kakao // 기본값은 kakao (하위 호환성)
+                
+                #if DEBUG
+                print("🚪 Revoking account with provider: \(provider.rawValue)")
+                #endif
+                
+                switch provider {
+                case .kakao:
+                    return self.repository.revokeKakao()
+                case .apple:
+                    return self.repository.revokeApple()
+                }
+            }
+            .flatMap { [weak self] _ -> AnyPublisher<Void, AuthError> in
+                guard let self = self else {
+                    return Fail(error: AuthError.unknownError("RevokeUseCase deallocated"))
+                        .eraseToAnyPublisher()
+                }
+                // 탈퇴 성공 시 토큰 삭제
+                return self.tokenStorage.deleteToken()
+                    .mapError { AuthError.fromKeychainError($0) }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+}
+

--- a/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/SignUpUseCase.swift
+++ b/beilsang/Projects/Domain/AuthDomain/Sources/UseCases/SignUpUseCase.swift
@@ -1,0 +1,103 @@
+//
+//  SignUpUseCase.swift
+//  AuthDomain
+//
+//  Created by Park Seyoung on 8/28/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import StorageCore
+
+public protocol SignUpUseCaseProtocol {
+    func checkNickname(_ nickname: String) -> AnyPublisher<Bool, AuthError>
+    func signUp(data: SignUpData) -> AnyPublisher<AuthState, Never>
+    func signUpSimplified(marketingAgreed: Bool) -> AnyPublisher<AuthState, Never>
+}
+
+public final class SignUpUseCase: SignUpUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+    private let tokenStorage: KeychainTokenStorageProtocol
+    
+    public init(repository: AuthRepositoryProtocol, tokenStorage: KeychainTokenStorageProtocol) {
+        self.repository = repository
+        self.tokenStorage = tokenStorage
+    }
+    
+    // MARK: - Nickname Check
+    public func checkNickname(_ nickname: String) -> AnyPublisher<Bool, AuthError> {
+        return repository.checkNickname(nickname)
+    }
+    
+    // MARK: - Sign Up
+    public func signUp(data: SignUpData) -> AnyPublisher<AuthState, Never> {
+        let request = data.toRequest()
+        
+        // 회원가입 전에 기존 토큰의 provider 정보 가져오기 (회원가입 전에 로그인했으므로)
+        return tokenStorage.getToken()
+            .mapError { _ in AuthError.unknownError("Failed to get existing token") }
+            .flatMap { [repository, tokenStorage] existingToken -> AnyPublisher<AuthState, AuthError> in
+                repository.signUp(request: request)
+                    .flatMap { newToken -> AnyPublisher<AuthState, AuthError> in
+                        // 기존 토큰의 provider 정보를 새 토큰에 유지
+                        let tokenWithProvider = KeychainToken(
+                            accessToken: newToken.accessToken,
+                            refreshToken: newToken.refreshToken,
+                            tokenType: newToken.tokenType,
+                            expiresIn: newToken.expiresIn,
+                            createdAt: newToken.createdAt,
+                            provider: existingToken?.provider // 기존 provider 유지
+                        )
+                        return tokenStorage.saveToken(tokenWithProvider)
+                            .map { AuthState.authenticated }
+                            .mapError { AuthError.fromKeychainError($0) }
+                            .eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .catch { error in Just(AuthState.error(error)) }
+            .prepend(.loading)
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Sign Up Simplified (약관 동의만)
+    public func signUpSimplified(marketingAgreed: Bool) -> AnyPublisher<AuthState, Never> {
+        // 기존 토큰의 provider 정보 가져오기
+        return tokenStorage.getToken()
+            .mapError { _ in AuthError.unknownError("Failed to get existing token") }
+            .flatMap { [repository, tokenStorage] existingToken -> AnyPublisher<AuthState, AuthError> in
+                guard let token = existingToken else {
+                    return Just(AuthState.error(.unknownError("No token found")))
+                        .setFailureType(to: AuthError.self)
+                        .eraseToAnyPublisher()
+                }
+                
+                let request = SignUpSimplifiedRequest(
+                    accessToken: token.accessToken,
+                    marketingAgreed: marketingAgreed
+                )
+                
+                return repository.signUpSimplified(request: request)
+                    .flatMap { newToken -> AnyPublisher<AuthState, AuthError> in
+                        // 기존 토큰의 provider 정보를 새 토큰에 유지
+                        let tokenWithProvider = KeychainToken(
+                            accessToken: newToken.accessToken,
+                            refreshToken: newToken.refreshToken,
+                            tokenType: newToken.tokenType,
+                            expiresIn: newToken.expiresIn,
+                            createdAt: newToken.createdAt,
+                            provider: existingToken?.provider // 기존 provider 유지
+                        )
+                        return tokenStorage.saveToken(tokenWithProvider)
+                            .map { AuthState.authenticated }
+                            .mapError { AuthError.fromKeychainError($0) }
+                            .eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .catch { error in Just(AuthState.error(error)) }
+            .prepend(.loading)
+            .eraseToAnyPublisher()
+    }
+}

--- a/beilsang/Projects/Domain/UserDomain/Derived/InfoPlists/UserDomain-Info.plist
+++ b/beilsang/Projects/Domain/UserDomain/Derived/InfoPlists/UserDomain-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/beilsang/Projects/Domain/UserDomain/Project.swift
+++ b/beilsang/Projects/Domain/UserDomain/Project.swift
@@ -1,0 +1,33 @@
+import ProjectDescription
+
+let project = Project(
+    name: "UserDomain",
+    settings: .settings(
+        base: [
+            "SWIFT_VERSION": "5.9"
+        ],
+        configurations: [
+            .debug(name: "dev"),
+            .debug(name: "stag"),
+            .release(name: "prod"),
+        ]
+    ),
+    targets: [
+        .target(
+            name: "UserDomain",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.beilsang.UserDomain",
+            deploymentTargets: .iOS("18.5"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            dependencies: [
+                .project(target: "ModelsShared", path: "../../Shared/Models"),
+                .project(target: "UtilityShared", path: "../../Shared/Utility"),
+                .project(target: "NetworkCore", path: "../../Core/NetworkCore"),
+                .project(target: "StorageCore", path: "../../Core/StorageCore"),
+                .external(name: "Alamofire")
+            ]
+        )
+    ]
+)

--- a/beilsang/Projects/Domain/UserDomain/Sources/Repositories/UserRepository.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/Repositories/UserRepository.swift
@@ -1,0 +1,505 @@
+//
+//  UserRepository.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+import Alamofire
+
+public final class UserRepository: UserRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+    
+    public init(baseURL: String) {
+        self.apiClient = APIClient(baseURL: baseURL)
+    }
+    
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Mock 데이터
+    private let mockUserProfile = UserProfileData(
+        resolution: "환경보호에 앞장서는 나",
+        points: 916,
+        nickName: "비밀상님",
+        profileImage: nil,
+        address: "서울시 마포구",
+        gender: "MAN",
+        birth: "2000-01-01",
+        feedDTOs: [
+            MyPageFeedDTO(feedId: 1, feedUrl: "challengeThumbnail1", day: 1),
+            MyPageFeedDTO(feedId: 2, feedUrl: "challengeThumbnail2", day: 2)
+        ],
+        countFeed: 20,
+        challenges: 6,
+        failedChallenges: 2,
+        successChallenge: 12,
+        likes: 24
+    )
+    
+    // MARK: - 사용자 프로필 조회
+    public func fetchUserProfile() async throws -> UserProfileData {
+        // Mock 데이터 사용 시
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("👤 Using mock user profile")
+            #endif
+            return mockUserProfile
+        }
+        
+        // 실제 API 호출
+        let path = "api/mypage"
+        
+        #if DEBUG
+        print("👤 Fetching user profile from API: GET /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<UserProfileResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("👤 User profile error: \(error)")
+                            #endif
+                            continuation.resume(throwing: UserRepository.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            #if DEBUG
+                            print("👤 User profile failed: \(response.message)")
+                            #endif
+                            continuation.resume(throwing: UserError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("👤 User profile loaded - nickname: \(data.nickname)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - 프로필 수정
+    public func updateProfile(request: ProfileUpdateRequest) async throws -> ProfileUpdateResponse {
+        // Mock 데이터 사용 시
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("👤 Using mock profile update")
+            #endif
+            return ProfileUpdateResponse(
+                nickName: request.nickName,
+                birth: request.birth,
+                gender: request.gender,
+                address: request.address,
+                resolution: request.resolution
+            )
+        }
+        
+        let path = "api/profile"
+        
+        #if DEBUG
+        print("👤 Updating profile: PATCH /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<ProfileUpdateAPIResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .patch,
+            body: request,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("👤 Profile update error: \(error)")
+                            #endif
+                            continuation.resume(throwing: UserRepository.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            #if DEBUG
+                            print("👤 Profile update failed: \(response.message)")
+                            #endif
+                            continuation.resume(throwing: UserError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("👤 Profile updated successfully")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - 프로필 이미지 수정
+    public func updateProfileImage(imageBase64: String) async throws -> String {
+        // Mock 데이터 사용 시
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("👤 Using mock profile image update")
+            #endif
+            return "https://example.com/profile/updated.jpg"
+        }
+        
+        let path = "api/profile/image"
+        let body = ProfileImageRequest(profileImage: imageBase64)
+        
+        #if DEBUG
+        print("👤 Updating profile image: PATCH /\(path)")
+        #endif
+        
+        // 서버가 200 + 빈 body 반환하므로 ModelsShared.EmptyResponse 사용
+        let publisher: AnyPublisher<ModelsShared.EmptyResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .patch,
+            body: body,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .failure(let error):
+                            // 디코딩 실패는 빈 응답일 수 있음 - 성공으로 처리
+                            if case .decoding = error {
+                                #if DEBUG
+                                print("👤 Profile image updated (empty response)")
+                                #endif
+                                continuation.resume(returning: "")
+                            } else {
+                                #if DEBUG
+                                print("👤 Profile image update error: \(error)")
+                                #endif
+                                continuation.resume(throwing: UserRepository.mapAPIError(error))
+                            }
+                        case .finished:
+                            break
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { _ in
+                        #if DEBUG
+                        print("👤 Profile image updated successfully")
+                        #endif
+                        continuation.resume(returning: "")
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - 내 피드 목록 조회
+    public func fetchMyFeeds(page: Int, size: Int) async throws -> FeedListResponse {
+        // Mock 데이터 사용 시
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📷 Using mock my feeds")
+            #endif
+            return FeedListResponse(
+                content: [
+                    FeedListItem(feedId: 1, feedUrl: "https://example.com/feed1.jpg", day: 1),
+                    FeedListItem(feedId: 2, feedUrl: "https://example.com/feed2.jpg", day: 2),
+                    FeedListItem(feedId: 3, feedUrl: "https://example.com/feed3.jpg", day: 3),
+                    FeedListItem(feedId: 4, feedUrl: "https://example.com/feed4.jpg", day: 4)
+                ],
+                number: page,
+                size: size,
+                numberOfElements: 4,
+                hasNext: false
+            )
+        }
+        
+        // 실제 API 호출
+        let path = "feed/my?page=\(page)&size=\(size)"
+        
+        #if DEBUG
+        print("📷 Fetching my feeds from API: GET /\(path)")
+        #endif
+        
+        typealias MyFeedsAPIResponse = APIResponse<FeedListResponse>
+        let publisher: AnyPublisher<MyFeedsAPIResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("📷 My feeds error: \(error)")
+                            #endif
+                            continuation.resume(throwing: UserRepository.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { apiResponse in
+                        guard apiResponse.isSuccess, let feedListResponse = apiResponse.data else {
+                            #if DEBUG
+                            print("📷 My feeds failed: \(apiResponse.message)")
+                            #endif
+                            continuation.resume(throwing: UserRepository.mapAPIError(APIClientError.http(statusCode: apiResponse.statusCode, data: nil)))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("📷 My feeds loaded - count: \(feedListResponse.content.count)")
+                        #endif
+                        continuation.resume(returning: feedListResponse)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - 포인트 내역 조회
+    public func fetchPoints() async throws -> PointData {
+        // Mock 데이터 사용 시
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("💰 Using mock points")
+            #endif
+            // 목업 데이터: 다양한 포인트 내역 생성
+            let calendar = Calendar.current
+            let today = Date()
+            
+            var mockPoints: [PointItem] = []
+            
+            // 적립 내역 (최근 30일)
+            mockPoints.append(PointItem(
+                id: 1,
+                name: "챌린지 인증 완료",
+                status: .earn,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -2, to: today)!),
+                period: 30
+            ))
+            mockPoints.append(PointItem(
+                id: 2,
+                name: "챌린지 인증 완료",
+                status: .earn,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -5, to: today)!),
+                period: 30
+            ))
+            mockPoints.append(PointItem(
+                id: 3,
+                name: "챌린지 인증 완료",
+                status: .earn,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -10, to: today)!),
+                period: 30
+            ))
+            mockPoints.append(PointItem(
+                id: 4,
+                name: "챌린지 인증 완료",
+                status: .earn,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -15, to: today)!),
+                period: 30
+            ))
+            mockPoints.append(PointItem(
+                id: 5,
+                name: "챌린지 달성 보너스",
+                status: .earn,
+                value: 500,
+                date: formatDate(calendar.date(byAdding: .day, value: -20, to: today)!),
+                period: 30
+            ))
+            mockPoints.append(PointItem(
+                id: 6,
+                name: "챌린지 인증 완료",
+                status: .earn,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -25, to: today)!),
+                period: 30
+            ))
+            
+            // 사용 내역
+            mockPoints.append(PointItem(
+                id: 7,
+                name: "챌린지 참여",
+                status: .use,
+                value: 1000,
+                date: formatDate(calendar.date(byAdding: .day, value: -3, to: today)!),
+                period: 0
+            ))
+            mockPoints.append(PointItem(
+                id: 8,
+                name: "챌린지 참여",
+                status: .use,
+                value: 1000,
+                date: formatDate(calendar.date(byAdding: .day, value: -12, to: today)!),
+                period: 0
+            ))
+            mockPoints.append(PointItem(
+                id: 9,
+                name: "챌린지 참여",
+                status: .use,
+                value: 1000,
+                date: formatDate(calendar.date(byAdding: .day, value: -18, to: today)!),
+                period: 0
+            ))
+            
+            // 소멸 내역
+            mockPoints.append(PointItem(
+                id: 10,
+                name: "소멸",
+                status: .expire,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -7, to: today)!),
+                period: 0
+            ))
+            mockPoints.append(PointItem(
+                id: 11,
+                name: "소멸",
+                status: .expire,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -14, to: today)!),
+                period: 0
+            ))
+            mockPoints.append(PointItem(
+                id: 12,
+                name: "소멸",
+                status: .expire,
+                value: 120,
+                date: formatDate(calendar.date(byAdding: .day, value: -22, to: today)!),
+                period: 0
+            ))
+            
+            // 총 포인트 계산 (적립 - 사용 - 소멸)
+            let totalEarned = mockPoints.filter { $0.status == .earn }.reduce(0) { $0 + $1.value }
+            let totalUsed = mockPoints.filter { $0.status == .use }.reduce(0) { $0 + $1.value }
+            let totalExpired = mockPoints.filter { $0.status == .expire }.reduce(0) { $0 + $1.value }
+            let total = totalEarned - totalUsed - totalExpired
+            
+            return PointData(
+                total: max(0, total),
+                points: mockPoints.sorted { item1, item2 in
+                    // 날짜 내림차순 정렬 (최신순)
+                    item1.date > item2.date
+                }
+            )
+        }
+        
+        // 실제 API 호출
+        let path = "api/mypage/point"
+        
+        #if DEBUG
+        print("💰 Fetching points from API: GET /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<PointResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("💰 Points error: \(error)")
+                            #endif
+                            continuation.resume(throwing: UserRepository.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.statusCode == 200 else {
+                            #if DEBUG
+                            print("💰 Points failed: \(response.message)")
+                            #endif
+                            continuation.resume(throwing: UserError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("💰 Points loaded - total: \(response.data.total), count: \(response.data.points.count)")
+                        #endif
+                        continuation.resume(returning: response.data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Helper
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+    
+    // MARK: - Error Mapping
+    private static func mapAPIError(_ error: APIClientError) -> UserError {
+        switch error {
+        case .http(let statusCode, _):
+            return .http(statusCode: statusCode)
+        case .network:
+            return .networkError
+        case .decoding:
+            return .decodingError
+        case .invalidURL:
+            return .invalidURL
+        }
+    }
+}
+
+// MARK: - UserError
+public enum UserError: Error {
+    case http(statusCode: Int)
+    case networkError
+    case decodingError
+    case invalidURL
+    case serverError(String)
+}
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/Repositories/UserRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/Repositories/UserRepositoryProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  UserRepositoryProtocol.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+
+public protocol UserRepositoryProtocol {
+    func fetchUserProfile() async throws -> UserProfileData
+    func updateProfile(request: ProfileUpdateRequest) async throws -> ProfileUpdateResponse
+    func updateProfileImage(imageBase64: String) async throws -> String
+    func fetchMyFeeds(page: Int, size: Int) async throws -> FeedListResponse
+    func fetchPoints() async throws -> PointData
+}
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchMyFeedsUseCase.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchMyFeedsUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchMyFeedsUseCase.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchMyFeedsUseCaseProtocol {
+    func execute(page: Int, size: Int) async throws -> FeedListResponse
+}
+
+public final class FetchMyFeedsUseCase: FetchMyFeedsUseCaseProtocol {
+    private let repository: UserRepositoryProtocol
+    
+    public init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(page: Int, size: Int) async throws -> FeedListResponse {
+        try await repository.fetchMyFeeds(page: page, size: size)
+    }
+}
+
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchPointsUseCase.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchPointsUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchPointsUseCase.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchPointsUseCaseProtocol {
+    func execute() async throws -> PointData
+}
+
+public final class FetchPointsUseCase: FetchPointsUseCaseProtocol {
+    private let repository: UserRepositoryProtocol
+    
+    public init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> PointData {
+        try await repository.fetchPoints()
+    }
+}
+
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchUserProfileUseCase.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/UseCases/FetchUserProfileUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchUserProfileUseCase.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchUserProfileUseCaseProtocol {
+    func execute() async throws -> UserProfileData
+}
+
+public final class FetchUserProfileUseCase: FetchUserProfileUseCaseProtocol {
+    private let repository: UserRepositoryProtocol
+    
+    public init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> UserProfileData {
+        try await repository.fetchUserProfile()
+    }
+}
+
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/UseCases/UpdateProfileImageUseCase.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/UseCases/UpdateProfileImageUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  UpdateProfileImageUseCase.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+
+public protocol UpdateProfileImageUseCaseProtocol {
+    /// Returns updated profile image URL if server provides it, otherwise empty string.
+    func execute(imageBase64: String) async throws -> String
+}
+
+public final class UpdateProfileImageUseCase: UpdateProfileImageUseCaseProtocol {
+    private let repository: UserRepositoryProtocol
+    
+    public init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(imageBase64: String) async throws -> String {
+        try await repository.updateProfileImage(imageBase64: imageBase64)
+    }
+}
+
+

--- a/beilsang/Projects/Domain/UserDomain/Sources/UseCases/UpdateProfileUseCase.swift
+++ b/beilsang/Projects/Domain/UserDomain/Sources/UseCases/UpdateProfileUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  UpdateProfileUseCase.swift
+//  UserDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol UpdateProfileUseCaseProtocol {
+    func execute(request: ProfileUpdateRequest) async throws -> ProfileUpdateResponse
+}
+
+public final class UpdateProfileUseCase: UpdateProfileUseCaseProtocol {
+    private let repository: UserRepositoryProtocol
+    
+    public init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(request: ProfileUpdateRequest) async throws -> ProfileUpdateResponse {
+        try await repository.updateProfile(request: request)
+    }
+}
+
+


### PR DESCRIPTION
## 📋 관련 이슈
Closes #2

## 🎯 작업 내용
인증 및 사용자 관련 Domain 레이어를 Repository Pattern과 UseCase로 구현

## 🏗️ 주요 변경사항

### AuthDomain
- **Repository**: AuthRepository (로그인, 회원가입, 로그아웃, 토큰 관리)
- **UseCase**: 
  - 소셜 로그인 (KakaoLoginUseCase, AppleLoginUseCase)
  - SignUpUseCase (5단계 온보딩)
  - LogoutUseCase, RevokeUseCase
- **Entity**: AuthState, SignUpData, AuthError

### UserDomain
- **Repository**: UserRepository (프로필, 포인트 관리)
- **UseCase**: 
  - FetchUserProfileUseCase, UpdateProfileUseCase
  - UpdateProfileImageUseCase, FetchPointsUseCase
  - FetchMyFeedsUseCase

## 💡 설계 패턴
- Repository Pattern: Protocol 기반 추상화
- UseCase Pattern: 단일 책임 원칙
- NetworkCore를 통한 API 호출

## 🧪 테스트
- [x] 빌드 성공
- [x] Repository/UseCase 컴파일 확인
