### PR TITLE
[#3] 🏆 Challenge & Notification Domain 구현 (Query/Command 분리)

### DIFF
--- a/beilsang/Projects/Domain/ChallengeDomain/Derived/InfoPlists/ChallengeDomain-Info.plist
+++ b/beilsang/Projects/Domain/ChallengeDomain/Derived/InfoPlists/ChallengeDomain-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/beilsang/Projects/Domain/ChallengeDomain/Project.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Project.swift
@@ -1,0 +1,33 @@
+import ProjectDescription
+
+let project = Project(
+    name: "ChallengeDomain",
+    settings: .settings(
+        base: [
+            "SWIFT_VERSION": "5.9"
+        ],
+        configurations: [
+            .debug(name: "dev"),
+            .debug(name: "stag"),
+            .release(name: "prod"),
+        ]
+    ),
+    targets: [
+        .target(
+            name: "ChallengeDomain",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.beilsang.ChallengeDomain",
+            deploymentTargets: .iOS("18.5"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            dependencies: [
+                .project(target: "ModelsShared", path: "../../Shared/Models"),
+                .project(target: "UtilityShared", path: "../../Shared/Utility"),
+                .project(target: "NetworkCore", path: "../../Core/NetworkCore"),
+                .project(target: "StorageCore", path: "../../Core/StorageCore"),
+                .external(name: "Alamofire")
+            ]
+        )
+    ]
+)

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/ChallengeCommandRepoImpl.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/ChallengeCommandRepoImpl.swift
@@ -1,0 +1,206 @@
+//
+//  ChallengeCommandRepoImpl.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+import Alamofire
+
+// MARK: - Empty Request
+private struct EmptyRequest: Codable, Sendable {}
+
+public final class ChallengeCommandRepoImpl: ChallengeCommandRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Participate in Challenge
+    public func participateInChallenge(challengeId: Int) async throws {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🎯 Using mock challenge participation - ID: \(challengeId)")
+            #endif
+            return
+        }
+        
+        let path = "challenge/\(challengeId)/join"
+        
+        #if DEBUG
+        print("🎯 Joining challenge - ID: \(challengeId)")
+        #endif
+        
+        let publisher: AnyPublisher<ChallengeJoinResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .post,
+            body: EmptyRequest(),
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("🎯 Challenge join error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        do {
+                            guard response.isSuccess else {
+                                throw ChallengeError.serverError(response.message)
+                            }
+                            
+                            #if DEBUG
+                            if let data = response.data {
+                                print("🎯 Challenge joined - Remaining points: \(data.remainingPoint)")
+                            }
+                            #endif
+                            
+                            continuation.resume()
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Report Challenge
+    public func reportChallenge(challengeId: Int) async throws {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🚨 Using mock challenge report - ID: \(challengeId)")
+            #endif
+            return
+        }
+        
+        // TODO: POST /api/challenges/{challengeId}/report
+        throw ChallengeError.notImplemented
+    }
+    
+    // MARK: - Create Challenge
+    public func createChallenge(request: ChallengeCreateRequest, infoImages: [Data], certImages: [Data]) async throws -> ChallengeCreateResponse {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🎯 Using mock challenge creation: \(request.title)")
+            #endif
+            return ChallengeCreateResponse(
+                challengeId: 999,
+                category: request.category,
+                title: request.title,
+                startDate: request.startDate,
+                finishDate: "",
+                joinPoint: request.joinPoint,
+                infoImageUrls: [],
+                certImageUrls: [],
+                details: request.details,
+                challengeNotes: request.notes,
+                period: request.period.rawValue,
+                totalGoalDay: request.totalGoalDay,
+                attendeeCount: 0,
+                countLikes: 0,
+                collectedPoint: 0
+            )
+        }
+        
+        let path = "challenge"
+        
+        #if DEBUG
+        print("🎯 Creating challenge: \(request.title)")
+        print("   infoImages: \(infoImages.count)개, certImages: \(certImages.count)개")
+        #endif
+        
+        let publisher: AnyPublisher<ModelsShared.EmptyResponse, APIClientError> = apiClient.uploadChallengeMultipart(
+            path: path,
+            data: request,
+            infoImages: infoImages,
+            certImages: certImages,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .failure(let error):
+                            if case .decoding = error {
+                                #if DEBUG
+                                print("🎯 Challenge created (empty response)")
+                                #endif
+                                let emptyResponse = ChallengeCreateResponse(
+                                    challengeId: 0,
+                                    category: request.category,
+                                    title: request.title,
+                                    startDate: request.startDate,
+                                    finishDate: "",
+                                    joinPoint: request.joinPoint,
+                                    infoImageUrls: [],
+                                    certImageUrls: [],
+                                    details: request.details,
+                                    challengeNotes: request.notes,
+                                    period: request.period.rawValue,
+                                    totalGoalDay: request.totalGoalDay,
+                                    attendeeCount: 0,
+                                    countLikes: 0,
+                                    collectedPoint: 0
+                                )
+                                continuation.resume(returning: emptyResponse)
+                            } else {
+                                #if DEBUG
+                                print("🎯 Challenge create error: \(error)")
+                                #endif
+                                continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                            }
+                        case .finished:
+                            break
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { _ in
+                        #if DEBUG
+                        print("🎯 Challenge created successfully")
+                        #endif
+                        let emptyResponse = ChallengeCreateResponse(
+                            challengeId: 0,
+                            category: request.category,
+                            title: request.title,
+                            startDate: request.startDate,
+                            finishDate: "",
+                            joinPoint: request.joinPoint,
+                            infoImageUrls: [],
+                            certImageUrls: [],
+                            details: request.details,
+                            challengeNotes: request.notes,
+                            period: request.period.rawValue,
+                            totalGoalDay: request.totalGoalDay,
+                            attendeeCount: 0,
+                            countLikes: 0,
+                            collectedPoint: 0
+                        )
+                        continuation.resume(returning: emptyResponse)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/ChallengeQueryRepoImpl.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/ChallengeQueryRepoImpl.swift
@@ -1,0 +1,397 @@
+//
+//  ChallengeQueryRepoImpl.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+
+// MARK: - Empty Request
+private struct EmptyRequest: Codable, Sendable {}
+
+public final class ChallengeQueryRepoImpl: ChallengeQueryRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Active Challenges
+    public func fetchActiveChallenges() async throws -> [Challenge] {
+        let request = ChallengeListRequest(
+            page: 0,
+            size: 20,
+            challengeStatus: .inProgress,
+            isJoined: true
+        )
+        return try await fetchChallengeList(request: request)
+    }
+    
+    // MARK: - Recommended Challenges
+    public func fetchRecommendedChallenges() async throws -> [Challenge] {
+        let request = ChallengeListRequest(
+            page: 0,
+            size: 10,
+            category: nil,
+            challengeStatus: nil,
+            isJoined: nil
+        )
+        return try await fetchChallengeList(request: request)
+    }
+    
+    // MARK: - Challenge List
+    public func fetchChallengeList(request: ChallengeListRequest) async throws -> [Challenge] {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🎯 Using mock challenge list")
+            #endif
+            // Mock 데이터는 MockChallengeData 사용
+            return Array(MockChallengeData.challenges.prefix(10))
+        }
+        
+        // Query parameters를 직접 path에 추가
+        var queryItems: [String] = []
+        
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .useDefaultKeys
+        
+        if let jsonData = try? encoder.encode(request),
+           let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
+            for (key, value) in dict {
+                if let stringValue = value as? String {
+                    queryItems.append("\(key)=\(stringValue)")
+                } else if let intValue = value as? Int {
+                    queryItems.append("\(key)=\(intValue)")
+                } else if let boolValue = value as? Bool {
+                    queryItems.append("\(key)=\(boolValue)")
+                }
+            }
+        }
+        
+        let path = "challenge?\(queryItems.joined(separator: "&"))"
+        
+        #if DEBUG
+        print("🎯 Fetching challenge list: \(path)")
+        #endif
+        
+        let publisher: AnyPublisher<ChallengeListResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("🎯 Challenge list error: \(error)")
+                            #endif
+                            if case .decoding = error {
+                                continuation.resume(returning: [])
+                            } else {
+                                continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                            }
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        do {
+                            guard response.isSuccess else {
+                                throw ChallengeError.serverError(response.message)
+                            }
+                            
+                            guard let data = response.data else {
+                                continuation.resume(returning: [])
+                                cancellable?.cancel()
+                                return
+                            }
+                            
+                            let challenges = data.content.map { item in
+                                ChallengeRepositoryHelpers.mapToChallenge(from: item)
+                            }
+                            continuation.resume(returning: challenges)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Challenge Detail
+    public func fetchChallengeDetail(challengeId: Int) async throws -> Challenge {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🎯 Using mock challenge detail - ID: \(challengeId)")
+            #endif
+            return MockChallengeData.challenges.first ?? MockChallengeData.challenges[0]
+        }
+        
+        let path = "challenge/\(challengeId)"
+        
+        #if DEBUG
+        print("🎯 Fetching challenge detail - ID: \(challengeId)")
+        #endif
+        
+        let publisher: AnyPublisher<ChallengeDetailResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("🎯 Challenge detail error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        do {
+                            guard response.isSuccess else {
+                                throw ChallengeError.serverError(response.message)
+                            }
+                            
+                            guard let data = response.data else {
+                                throw ChallengeError.serverError("챌린지 데이터가 없습니다.")
+                            }
+                            
+                            let challenge = ChallengeRepositoryHelpers.mapToChallenge(from: data)
+                            continuation.resume(returning: challenge)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Feed Thumbnails
+    public func fetchChallengeFeedThumbnails(challengeId: Int, page: Int?) async throws -> ChallengeFeedThumbnailResponse {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📷 Using mock challenge feed thumbnails - challengeId: \(challengeId)")
+            #endif
+            let mockThumbnails: [ChallengeFeedThumbnail] = (1...8).map {
+                ChallengeFeedThumbnail(
+                    feedId: $0,
+                    feedUrl: $0 % 2 == 0 ? "challengeThumbnail2" : "challengeThumbnail1",
+                    day: $0,
+                    isMyFeed: $0 % 3 == 0
+                )
+            }
+            return ChallengeFeedThumbnailResponse(feeds: mockThumbnails, hasNext: (page ?? 0) < 2)
+        }
+        
+        let mockThumbnails: [ChallengeFeedThumbnail] = (1...8).map {
+            ChallengeFeedThumbnail(
+                feedId: $0,
+                feedUrl: $0 % 2 == 0 ? "challengeThumbnail2" : "challengeThumbnail1",
+                day: $0,
+                isMyFeed: $0 % 3 == 0
+            )
+        }
+        return ChallengeFeedThumbnailResponse(feeds: mockThumbnails, hasNext: (page ?? 0) < 2)
+    }
+    
+    // MARK: - Hall of Fame
+    public func fetchHonorsChallenges(by keyword: Keyword) async throws -> [Challenge] {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🏆 Using mock hall of fame - category: \(keyword.apiCategory)")
+            #endif
+            return Array(MockChallengeData.challenges.prefix(5))
+        }
+        
+        let category = keyword.apiCategory
+        let path = "api/achievement/hall-of-fame/\(category)"
+        
+        #if DEBUG
+        print("🏆 Fetching hall of fame - category: \(category)")
+        #endif
+        
+        let publisher: AnyPublisher<HallOfFameResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("🏆 Hall of fame error: \(error)")
+                            #endif
+                            if case .decoding = error {
+                                continuation.resume(returning: [])
+                            } else {
+                                continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                            }
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        do {
+                            guard response.isSuccess else {
+                                throw ChallengeError.serverError(response.message)
+                            }
+                            
+                            guard let data = response.data else {
+                                continuation.resume(returning: [])
+                                cancellable?.cancel()
+                                return
+                            }
+                            
+                            let challenges = data.challenges.map { item in
+                                ChallengeRepositoryHelpers.mapToChallenge(from: item)
+                            }
+                            continuation.resume(returning: challenges)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Keyword Feeds
+    public func fetchKeywordFeeds(by keyword: Keyword, page: Int) async throws -> [ChallengeFeedDetail] {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔍 Using mock keyword feeds - keyword: \(keyword.title)")
+            #endif
+            return []
+        }
+        
+        let category = keyword.apiCategory
+        let path = "feed?category=\(category)&page=\(page)&size=10"
+        
+        #if DEBUG
+        print("🔍 Fetching keyword feeds - keyword: \(keyword.title), page: \(page)")
+        #endif
+        
+        let publisher: AnyPublisher<FeedsByCategoryResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("🔍 Keyword feeds error: \(error)")
+                            #endif
+                            if case .decoding = error {
+                                continuation.resume(returning: [])
+                            } else {
+                                continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                            }
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        do {
+                            guard response.isSuccess else {
+                                throw ChallengeError.serverError(response.message)
+                            }
+                            
+                            guard let data = response.data else {
+                                continuation.resume(returning: [])
+                                cancellable?.cancel()
+                                return
+                            }
+                            
+                            let feeds = data.content.map { item in
+                                ChallengeRepositoryHelpers.mapToFeedDetail(from: item, keyword: keyword)
+                            }
+                            continuation.resume(returning: feeds)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Challenge Enrollment Check
+    public func checkChallengeEnrollment(challengeId: Int) async throws -> ChallengeEnrollmentData {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("✅ Using mock challenge enrollment check")
+            #endif
+            return ChallengeEnrollmentData(isEnrolled: false, enrolledChallengeIds: [])
+        }
+        
+        let path = "challenge/\(challengeId)/enrollment"
+        
+        #if DEBUG
+        print("✅ Checking challenge enrollment - ID: \(challengeId)")
+        #endif
+        
+        let publisher: AnyPublisher<ChallengeEnrollmentResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("✅ Challenge enrollment check error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("✅ Challenge enrollment status: \(data.isEnrolled)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/FeedRepoImpl.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Impl/FeedRepoImpl.swift
@@ -1,0 +1,347 @@
+//
+//  FeedRepoImpl.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+import Alamofire
+
+public final class FeedRepoImpl: FeedRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Feed List
+    public func fetchFeedList(category: String?, page: Int, size: Int) async throws -> FeedListResponse {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📷 Using mock feed list")
+            #endif
+            return FeedListResponse(
+                content: [],
+                number: page,
+                size: size,
+                numberOfElements: 0,
+                hasNext: false
+            )
+        }
+        
+        var path = "feed?page=\(page)&size=\(size)"
+        if let category = category {
+            path += "&category=\(category)"
+        }
+        
+        #if DEBUG
+        print("📷 Fetching feed list: \(path)")
+        #endif
+        
+        let publisher: AnyPublisher<APIResponse<FeedListResponse>, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("📷 Feed list error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { apiResponse in
+                        guard apiResponse.statusCode == 200, let response = apiResponse.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(apiResponse.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("📷 Feed list loaded - count: \(response.content.count)")
+                        #endif
+                        continuation.resume(returning: response)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Create Feed
+    public func createFeed(request: FeedCreateRequest) async throws -> FeedCreateData {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📝 Using mock feed creation - challengeId: \(request.challengeId)")
+            #endif
+            return FeedCreateData(
+                feedId: Int.random(in: 100...999),
+                challengeTitle: "Mock Challenge",
+                review: request.review,
+                feedUrl: "challengeThumbnail1",
+                uploadDate: ISO8601DateFormatter().string(from: Date()),
+                createdAt: ISO8601DateFormatter().string(from: Date())
+            )
+        }
+        
+        let path = "feed"
+        
+        #if DEBUG
+        print("📝 Creating feed for challenge: \(request.challengeId)")
+        #endif
+        
+        let parameters = [
+            "challengeId": "\(request.challengeId)",
+            "review": request.review
+        ]
+        
+        let publisher: AnyPublisher<FeedCreateResponse, APIClientError> = apiClient.uploadMultipart(
+            path: path,
+            parameters: parameters,
+            imageData: request.feedImage,
+            imageKey: "feedImage",
+            imageName: "feed_\(Date().timeIntervalSince1970).jpg",
+            mimeType: "image/jpeg",
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("📝 Feed create error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("📝 Feed created successfully - feedId: \(data.feedId)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Feed Detail
+    public func fetchFeedDetailData(feedId: Int) async throws -> FeedDetailData {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("📄 Using mock feed detail - feedId: \(feedId)")
+            #endif
+            return FeedDetailData(
+                feedId: feedId,
+                memberInfo: MemberInfo(
+                    memberId: 1,
+                    nickName: "비밀상님",
+                    profileImage: ""
+                ),
+                challengeId: 1,
+                challengeTitle: "플로깅",
+                challengeCategory: "plogging",
+                review: "오늘도 환경을 지키며 운동했습니다!",
+                feedUrl: feedId % 2 == 0 ? "challengeThumbnail2" : "challengeThumbnail1",
+                uploadDate: ISO8601DateFormatter().string(from: Date()),
+                likeCount: 15 + feedId,
+                isLiked: feedId % 3 == 0,
+                createdAt: ISO8601DateFormatter().string(from: Date()),
+                updatedAt: ISO8601DateFormatter().string(from: Date())
+            )
+        }
+        
+        let path = "feed/\(feedId)"
+        
+        #if DEBUG
+        print("📄 Fetching feed detail - feedId: \(feedId)")
+        #endif
+        
+        let publisher: AnyPublisher<FeedDetailResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("📄 Feed detail error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("📄 Feed detail loaded - feedId: \(data.feedId)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Challenge Feed Detail (변환)
+    public func fetchChallengeFeedDetail(feedId: Int) async throws -> ChallengeFeedDetail {
+        let data = try await fetchFeedDetailData(feedId: feedId)
+        
+        // FeedDetailData를 ChallengeFeedDetail로 변환
+        return ChallengeFeedDetail(
+            id: data.feedId,
+            feedUrl: data.feedUrl,
+            day: 0,
+            userName: data.memberInfo.nickName,
+            userProfileImageUrl: data.memberInfo.profileImage,
+            description: data.review,
+            likeCount: data.likeCount,
+            isLiked: data.isLiked,
+            challengeTags: [data.challengeCategory],
+            createdAt: ChallengeRepositoryHelpers.parseDate(data.createdAt) ?? Date(),
+            isMyFeed: false
+        )
+    }
+    
+    // MARK: - Toggle Feed Like
+    public func toggleFeedLike(feedId: Int, currentlyLiked: Bool) async throws -> FeedLikeData {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("❤️ Using mock feed like toggle - feedId: \(feedId), currentlyLiked: \(currentlyLiked)")
+            #endif
+            return FeedLikeData(
+                feedId: feedId,
+                likeCount: currentlyLiked ? 14 : 15,
+                isLiked: !currentlyLiked
+            )
+        }
+        
+        let path = "feed/\(feedId)/like"
+        
+        #if DEBUG
+        print("❤️ Toggling feed like - feedId: \(feedId), currentlyLiked: \(currentlyLiked)")
+        #endif
+        
+        if currentlyLiked {
+            return try await removeFeedLike(feedId: feedId, path: path)
+        } else {
+            return try await addFeedLike(feedId: feedId, path: path)
+        }
+    }
+    
+    // MARK: - Private Helpers
+    private func addFeedLike(feedId: Int, path: String) async throws -> FeedLikeData {
+        struct EmptyRequest: Encodable, Sendable {}
+        
+        let publisher: AnyPublisher<FeedLikeResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .post,
+            body: EmptyRequest(),
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("❤️ Feed like POST error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("❤️ Feed like added - feedId: \(data.feedId), isLiked: \(data.isLiked)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+    
+    private func removeFeedLike(feedId: Int, path: String) async throws -> FeedLikeData {
+        let publisher: AnyPublisher<FeedLikeResponse, APIClientError> = apiClient.request(
+            path: path,
+            method: .delete,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            #if DEBUG
+                            print("❤️ Feed like DELETE error: \(error)")
+                            #endif
+                            continuation.resume(throwing: ChallengeRepositoryHelpers.mapAPIError(error))
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard response.isSuccess, let data = response.data else {
+                            continuation.resume(throwing: ChallengeError.serverError(response.message))
+                            cancellable?.cancel()
+                            return
+                        }
+                        
+                        #if DEBUG
+                        print("❤️ Feed like removed - feedId: \(data.feedId), isLiked: \(data.isLiked)")
+                        #endif
+                        continuation.resume(returning: data)
+                        cancellable?.cancel()
+                    }
+                )
+        }
+    }
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Mocks/MockChallengeData.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Mocks/MockChallengeData.swift
@@ -1,0 +1,85 @@
+//
+//  MockChallengeData.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+public struct MockChallengeData {
+    public static let challenges: [Challenge] = [
+        Challenge(
+            id: 1,
+            title: "플로깅",
+            description: "환경을 지키는 첫 걸음, 함께하는 플로깅 챌린지!",
+            category: "plogging",
+            memberStatus: .ongoing,
+            progress: 30.0,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400 * 30),
+            author: "나지롱",
+            currentParticipants: 30,
+            maxParticipants: 100,
+            depositAmount: 1000,
+            certificationMethod: "사진 인증",
+            infoImageUrls: ["challengeThumbnail1"],
+            certImageUrls: ["certImage1"],
+            thumbnailImageUrl: "challengeThumbnail1",
+            isLiked: false,
+            likeCount: 77,
+            isParticipating: true,
+            isRecruitmentClosed: false,
+            createdAt: Date()
+        ),
+        Challenge(
+            id: 2,
+            title: "자전거 출퇴근",
+            description: "출퇴근길을 자전거로! 탄소 절감과 건강을 동시에.",
+            category: "bicycle",
+            memberStatus: .notYet,
+            progress: 0.0,
+            startDate: Date().addingTimeInterval(86400 * 7),
+            endDate: Date().addingTimeInterval(86400 * 21),
+            author: "멀린멀린",
+            currentParticipants: 0,
+            maxParticipants: 50,
+            depositAmount: 2000,
+            certificationMethod: "GPS 트래킹",
+            infoImageUrls: ["challengeThumbnail1"],
+            certImageUrls: [],
+            thumbnailImageUrl: "challengeThumbnail1",
+            isLiked: true,
+            likeCount: 50,
+            isParticipating: false,
+            isRecruitmentClosed: false,
+            createdAt: Date()
+        ),
+        Challenge(
+            id: 3,
+            title: "등산 인증",
+            description: "매주 산에 오르며 건강을 챙겨보세요.",
+            category: "hiking",
+            memberStatus: .ongoing,
+            progress: 50.0,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(86400 * 20),
+            author: "박세영이지롱",
+            currentParticipants: 15,
+            maxParticipants: 40,
+            depositAmount: 1500,
+            certificationMethod: "사진 인증",
+            infoImageUrls: ["challengeThumbnail2"],
+            certImageUrls: ["certImage1"],
+            thumbnailImageUrl: "challengeThumbnail2",
+            isLiked: true,
+            likeCount: 43,
+            isParticipating: false,
+            isRecruitmentClosed: false,
+            createdAt: Date()
+        ),
+        // NOTE: Mock 데이터는 최소화 (실제로는 더 많은 데이터를 원하면 추가)
+    ]
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeCommandRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeCommandRepositoryProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  ChallengeCommandRepositoryProtocol.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+/// 챌린지 변경 작업 전용 Repository
+public protocol ChallengeCommandRepositoryProtocol {
+    func participateInChallenge(challengeId: Int) async throws
+    func reportChallenge(challengeId: Int) async throws
+    func createChallenge(request: ChallengeCreateRequest, infoImages: [Data], certImages: [Data]) async throws -> ChallengeCreateResponse
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeQueryRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeQueryRepositoryProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  ChallengeQueryRepositoryProtocol.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+/// 챌린지 조회 전용 Repository
+public protocol ChallengeQueryRepositoryProtocol {
+    func fetchActiveChallenges() async throws -> [Challenge]
+    func fetchRecommendedChallenges() async throws -> [Challenge]
+    func fetchChallengeList(request: ChallengeListRequest) async throws -> [Challenge]
+    func fetchChallengeDetail(challengeId: Int) async throws -> Challenge
+    func fetchChallengeFeedThumbnails(challengeId: Int, page: Int?) async throws -> ChallengeFeedThumbnailResponse
+    func fetchHonorsChallenges(by keyword: Keyword) async throws -> [Challenge]
+    func fetchKeywordFeeds(by keyword: Keyword, page: Int) async throws -> [ChallengeFeedDetail]
+    func checkChallengeEnrollment(challengeId: Int) async throws -> ChallengeEnrollmentData
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepository.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepository.swift
@@ -1,0 +1,100 @@
+//
+//  ChallengeRepository.swift (Facade)
+//  ChallengeDomain
+//
+//  Refactored by Seyoung Park on 12/26/25.
+//  Original implementation분 분리된 Impl 파일들로 이동
+//
+
+import Foundation
+import ModelsShared
+import NetworkCore
+
+/// Facade Pattern: 기존 인터페이스 유지하면서 내부 구현을 분리된 Repository들로 위임
+public final class ChallengeRepository: ChallengeRepositoryProtocol {
+    private let queryRepo: ChallengeQueryRepositoryProtocol
+    private let commandRepo: ChallengeCommandRepositoryProtocol
+    private let feedRepo: FeedRepositoryProtocol
+    
+    // MARK: - Init
+    public init(baseURL: String) {
+        let apiClient = APIClient(baseURL: baseURL)
+        self.queryRepo = ChallengeQueryRepoImpl(apiClient: apiClient)
+        self.commandRepo = ChallengeCommandRepoImpl(apiClient: apiClient)
+        self.feedRepo = FeedRepoImpl(apiClient: apiClient)
+    }
+    
+    public init(apiClient: APIClientProtocol) {
+        self.queryRepo = ChallengeQueryRepoImpl(apiClient: apiClient)
+        self.commandRepo = ChallengeCommandRepoImpl(apiClient: apiClient)
+        self.feedRepo = FeedRepoImpl(apiClient: apiClient)
+    }
+    
+    // MARK: - Query Methods (위임)
+    public func fetchActiveChallenges() async throws -> [Challenge] {
+        try await queryRepo.fetchActiveChallenges()
+    }
+    
+    public func fetchRecommendedChallenges() async throws -> [Challenge] {
+        try await queryRepo.fetchRecommendedChallenges()
+    }
+    
+    public func fetchChallengeList(request: ChallengeListRequest) async throws -> [Challenge] {
+        try await queryRepo.fetchChallengeList(request: request)
+    }
+    
+    public func fetchChallengeDetail(challengeId: Int) async throws -> Challenge {
+        try await queryRepo.fetchChallengeDetail(challengeId: challengeId)
+    }
+    
+    public func fetchChallengeFeedThumbnails(challengeId: Int, page: Int?) async throws -> ChallengeFeedThumbnailResponse {
+        try await queryRepo.fetchChallengeFeedThumbnails(challengeId: challengeId, page: page)
+    }
+    
+    public func fetchChallengeFeedDetail(feedId: Int) async throws -> ChallengeFeedDetail {
+        try await feedRepo.fetchChallengeFeedDetail(feedId: feedId)
+    }
+    
+    public func fetchHonorsChallenges(by keyword: Keyword) async throws -> [Challenge] {
+        try await queryRepo.fetchHonorsChallenges(by: keyword)
+    }
+    
+    public func fetchKeywordFeeds(by keyword: Keyword, page: Int) async throws -> [ChallengeFeedDetail] {
+        try await queryRepo.fetchKeywordFeeds(by: keyword, page: page)
+    }
+    
+    public func checkChallengeEnrollment(challengeId: Int) async throws -> ChallengeEnrollmentData {
+        try await queryRepo.checkChallengeEnrollment(challengeId: challengeId)
+    }
+    
+    // MARK: - Command Methods (위임)
+    public func participateInChallenge(challengeId: Int) async throws {
+        try await commandRepo.participateInChallenge(challengeId: challengeId)
+    }
+    
+    public func reportChallenge(challengeId: Int) async throws {
+        try await commandRepo.reportChallenge(challengeId: challengeId)
+    }
+    
+    public func createChallenge(request: ChallengeCreateRequest, infoImages: [Data], certImages: [Data]) async throws -> ChallengeCreateResponse {
+        try await commandRepo.createChallenge(request: request, infoImages: infoImages, certImages: certImages)
+    }
+    
+    // MARK: - Feed Methods (위임)
+    public func fetchFeedList(category: String?, page: Int, size: Int) async throws -> FeedListResponse {
+        try await feedRepo.fetchFeedList(category: category, page: page, size: size)
+    }
+    
+    public func createFeed(request: FeedCreateRequest) async throws -> FeedCreateData {
+        try await feedRepo.createFeed(request: request)
+    }
+    
+    public func fetchFeedDetailData(feedId: Int) async throws -> FeedDetailData {
+        try await feedRepo.fetchFeedDetailData(feedId: feedId)
+    }
+    
+    public func toggleFeedLike(feedId: Int, currentlyLiked: Bool) async throws -> FeedLikeData {
+        try await feedRepo.toggleFeedLike(feedId: feedId, currentlyLiked: currentlyLiked)
+    }
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepositoryHelpers.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepositoryHelpers.swift
@@ -1,0 +1,147 @@
+//
+//  ChallengeRepositoryHelpers.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import ModelsShared
+import NetworkCore
+
+// MARK: - Error Mapping
+public enum ChallengeError: Error, LocalizedError {
+    case invalidRequest
+    case networkError(String)
+    case serverError(String)
+    case notImplemented
+    
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRequest:
+            return "잘못된 요청입니다."
+        case .networkError(let message):
+            return "네트워크 오류: \(message)"
+        case .serverError(let message):
+            return "서버 오류: \(message)"
+        case .notImplemented:
+            return "아직 구현되지 않았습니다."
+        }
+    }
+}
+
+public struct ChallengeRepositoryHelpers {
+    public static func mapAPIError(_ error: APIClientError) -> ChallengeError {
+        switch error {
+        case .invalidURL:
+            return .invalidRequest
+        case .http(let statusCode, _):
+            return .networkError("HTTP \(statusCode)")
+        case .decoding(let message, _):
+            return .networkError(message)
+        case .network(let error):
+            return .networkError(error.localizedDescription)
+        }
+    }
+    
+    public static func mapToChallenge(from item: HallOfFameChallenge) -> Challenge {
+        Challenge(
+            id: item.challengeId,
+            title: item.title,
+            description: "",
+            category: item.category,
+            memberStatus: .ongoing,
+            progress: 0,
+            startDate: parseDate(item.startDate) ?? Date(),
+            endDate: parseDate(item.finishDate) ?? Date(),
+            author: "",
+            currentParticipants: item.attendeeCount,
+            maxParticipants: item.attendeeCount,
+            depositAmount: 0,
+            certificationMethod: "",
+            infoImageUrls: item.infoImageUrls,
+            certImageUrls: [],
+            thumbnailImageUrl: item.infoImageUrls.first ?? "",
+            isLiked: false,
+            likeCount: item.likeCount,
+            isParticipating: false,
+            isRecruitmentClosed: true,
+            createdAt: Date()
+        )
+    }
+    
+    public static func mapToChallenge(from item: ChallengeListItem) -> Challenge {
+        Challenge(
+            id: item.id,
+            title: item.title,
+            description: item.description,
+            category: item.category,
+            memberStatus: item.status,
+            progress: 0,
+            startDate: Date(),
+            endDate: Date(),
+            author: "",
+            currentParticipants: item.participantCount,
+            maxParticipants: item.participantCount,
+            depositAmount: 0,
+            certificationMethod: "",
+            infoImageUrls: [item.imageUrl],
+            certImageUrls: [],
+            thumbnailImageUrl: item.imageUrl,
+            isLiked: false,
+            likeCount: item.likeCount,
+            isParticipating: false,
+            isRecruitmentClosed: item.isRecruitmentClosed,
+            createdAt: Date()
+        )
+    }
+    
+    public static func mapToChallenge(from data: ChallengeDetailData) -> Challenge {
+        Challenge(
+            id: data.challengeId,
+            title: data.title,
+            description: data.description,
+            category: data.category,
+            memberStatus: data.status,
+            progress: data.progress,
+            startDate: parseDate(data.startDate) ?? Date(),
+            endDate: parseDate(data.finishDate) ?? Date(),
+            author: "",
+            currentParticipants: data.attendeeCount,
+            maxParticipants: data.attendeeCount,
+            depositAmount: data.joinPoint,
+            certificationMethod: data.challengeNotes.joined(separator: "\n"),
+            infoImageUrls: data.infoImageUrls,
+            certImageUrls: data.certImageUrls,
+            thumbnailImageUrl: data.infoImageUrls.first,
+            isLiked: false,
+            likeCount: data.likeCount,
+            isParticipating: !data.isJoinable,
+            isRecruitmentClosed: data.isRecruitmentClosed,
+            createdAt: Date()
+        )
+    }
+    
+    public static func mapToFeedDetail(from item: FeedItem, keyword: Keyword) -> ChallengeFeedDetail {
+        ChallengeFeedDetail(
+            id: item.feedId,
+            feedUrl: item.feedUrl,
+            day: item.day,
+            userName: "User",
+            userProfileImageUrl: nil,
+            description: "",
+            likeCount: 0,
+            isLiked: false,
+            challengeTags: [keyword.title],
+            createdAt: Date(),
+            isMyFeed: false
+        )
+    }
+    
+    public static func parseDate(_ dateString: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate]
+        return formatter.date(from: dateString)
+    }
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/ChallengeRepositoryProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  ChallengeRepositoryProtocol.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 10/7/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol ChallengeRepositoryProtocol {
+    func fetchActiveChallenges() async throws -> [Challenge]
+    func fetchRecommendedChallenges() async throws -> [Challenge]
+    func fetchChallengeList(request: ChallengeListRequest) async throws -> [Challenge]
+    func fetchChallengeDetail(challengeId: Int) async throws -> Challenge
+    func participateInChallenge(challengeId: Int) async throws
+    func reportChallenge(challengeId: Int) async throws
+    func fetchChallengeFeedThumbnails(challengeId: Int, page: Int?) async throws -> ChallengeFeedThumbnailResponse
+    func fetchChallengeFeedDetail(feedId: Int) async throws -> ChallengeFeedDetail
+    func fetchHonorsChallenges(by keyword: Keyword) async throws -> [Challenge]
+    func fetchKeywordFeeds(by keyword: Keyword, page: Int) async throws -> [ChallengeFeedDetail]
+    func createChallenge(request: ChallengeCreateRequest, infoImages: [Data], certImages: [Data]) async throws -> ChallengeCreateResponse
+    func fetchFeedList(category: String?, page: Int, size: Int) async throws -> FeedListResponse
+    func createFeed(request: FeedCreateRequest) async throws -> FeedCreateData
+    func fetchFeedDetailData(feedId: Int) async throws -> FeedDetailData
+    func toggleFeedLike(feedId: Int, currentlyLiked: Bool) async throws -> FeedLikeData
+    func checkChallengeEnrollment(challengeId: Int) async throws -> ChallengeEnrollmentData
+}

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/FeedRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/Repositories/FeedRepositoryProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  FeedRepositoryProtocol.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+/// 피드 관련 Repository
+public protocol FeedRepositoryProtocol {
+    func fetchFeedList(category: String?, page: Int, size: Int) async throws -> FeedListResponse
+    func createFeed(request: FeedCreateRequest) async throws -> FeedCreateData
+    func fetchFeedDetailData(feedId: Int) async throws -> FeedDetailData
+    func fetchChallengeFeedDetail(feedId: Int) async throws -> ChallengeFeedDetail
+    func toggleFeedLike(feedId: Int, currentlyLiked: Bool) async throws -> FeedLikeData
+}
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/CheckChallengeEnrollmentUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/CheckChallengeEnrollmentUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  CheckChallengeEnrollmentUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol CheckChallengeEnrollmentUseCaseProtocol {
+    func execute(challengeId: Int) async throws -> ChallengeEnrollmentData
+}
+
+public final class CheckChallengeEnrollmentUseCase: CheckChallengeEnrollmentUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(challengeId: Int) async throws -> ChallengeEnrollmentData {
+        try await repository.checkChallengeEnrollment(challengeId: challengeId)
+    }
+}
+
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/CreateChallengeUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/CreateChallengeUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  CreateChallengeUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol CreateChallengeUseCaseProtocol {
+    func execute(
+        request: ChallengeCreateRequest,
+        infoImages: [Data],
+        certImages: [Data]
+    ) async throws -> ChallengeCreateResponse
+}
+
+public final class CreateChallengeUseCase: CreateChallengeUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(
+        request: ChallengeCreateRequest,
+        infoImages: [Data],
+        certImages: [Data]
+    ) async throws -> ChallengeCreateResponse {
+        try await repository.createChallenge(
+            request: request,
+            infoImages: infoImages,
+            certImages: certImages
+        )
+    }
+}

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchActiveChallengesUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchActiveChallengesUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchActiveChallengesUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchActiveChallengesUseCaseProtocol {
+    func execute() async throws -> [Challenge]
+}
+
+public final class FetchActiveChallengesUseCase: FetchActiveChallengesUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> [Challenge] {
+        try await repository.fetchActiveChallenges()
+    }
+}
+
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeDetailUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeDetailUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchChallengeDetailUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchChallengeDetailUseCaseProtocol {
+    func execute(challengeId: Int) async throws -> Challenge
+}
+
+public final class FetchChallengeDetailUseCase: FetchChallengeDetailUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(challengeId: Int) async throws -> Challenge {
+        try await repository.fetchChallengeDetail(challengeId: challengeId)
+    }
+}

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeFeedThumbnailsUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeFeedThumbnailsUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchChallengeFeedThumbnailsUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchChallengeFeedThumbnailsUseCaseProtocol {
+    func execute(challengeId: Int, page: Int?) async throws -> ChallengeFeedThumbnailResponse
+}
+
+public final class FetchChallengeFeedThumbnailsUseCase: FetchChallengeFeedThumbnailsUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(challengeId: Int, page: Int? = nil) async throws -> ChallengeFeedThumbnailResponse {
+        try await repository.fetchChallengeFeedThumbnails(challengeId: challengeId, page: page)
+    }
+}
+
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeListUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchChallengeListUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  FetchChallengeListUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchChallengeListUseCaseProtocol {
+    func execute(request: ChallengeListRequest) async throws -> [Challenge]
+}
+
+public final class FetchChallengeListUseCase: FetchChallengeListUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(request: ChallengeListRequest) async throws -> [Challenge] {
+        try await repository.fetchChallengeList(request: request)
+    }
+}
+
+
+
+
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchRecommendedChallengesUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/FetchRecommendedChallengesUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchRecommendedChallengesUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 12/02/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol FetchRecommendedChallengesUseCaseProtocol {
+    func execute() async throws -> [Challenge]
+}
+
+public final class FetchRecommendedChallengesUseCase: FetchRecommendedChallengesUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> [Challenge] {
+        try await repository.fetchRecommendedChallenges()
+    }
+}
+
+

--- a/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/JoinChallengeUseCase.swift
+++ b/beilsang/Projects/Domain/ChallengeDomain/Sources/UseCases/JoinChallengeUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  JoinChallengeUseCase.swift
+//  ChallengeDomain
+//
+//  Created by Seyoung Park on 11/26/25.
+//
+
+import Foundation
+
+public protocol JoinChallengeUseCaseProtocol {
+    func execute(challengeId: Int) async throws
+}
+
+public final class JoinChallengeUseCase: JoinChallengeUseCaseProtocol {
+    private let repository: ChallengeRepositoryProtocol
+    
+    public init(repository: ChallengeRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(challengeId: Int) async throws {
+        try await repository.participateInChallenge(challengeId: challengeId)
+    }
+}

--- a/beilsang/Projects/Domain/NotificationDomain/Derived/InfoPlists/NotificationDomain-Info.plist
+++ b/beilsang/Projects/Domain/NotificationDomain/Derived/InfoPlists/NotificationDomain-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/beilsang/Projects/Domain/NotificationDomain/Project.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Project.swift
@@ -1,0 +1,40 @@
+import ProjectDescription
+
+let project = Project(
+    name: "NotificationDomain",
+    settings: .settings(
+        base: [
+            "SWIFT_VERSION": "5.9"
+        ],
+        configurations: [
+            .debug(name: "dev"),
+            .debug(name: "stag"),
+            .release(name: "prod"),
+        ]
+    ),
+    targets: [
+        .target(
+            name: "NotificationDomain",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.beilsang.NotificationDomain",
+            deploymentTargets: .iOS("18.5"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            dependencies: [
+                .project(target: "ModelsShared", path: "../../Shared/Models"),
+                .project(target: "UtilityShared", path: "../../Shared/Utility"),
+                .project(target: "NetworkCore", path: "../../Core/NetworkCore"),
+                .project(target: "StorageCore", path: "../../Core/StorageCore"),
+                .external(name: "Alamofire")
+            ]
+        )
+    ]
+)
+
+
+
+
+
+
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/Repositories/NotificationRepository.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/Repositories/NotificationRepository.swift
@@ -1,0 +1,233 @@
+//
+//  NotificationRepository.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+import Combine
+import ModelsShared
+import NetworkCore
+import UtilityShared
+import Alamofire
+
+public final class NotificationRepository: NotificationRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+    
+    public init(baseURL: String) {
+        self.apiClient = APIClient(baseURL: baseURL)
+    }
+    
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - Fetch Notifications
+    public func fetchNotifications(page: Int, size: Int) async throws -> NotificationListResponse {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔔 Using mock notifications")
+            #endif
+            // Mock 응답
+            let mockNotifications = ModelsShared.Notification.mockData.map { notification in
+                NotificationDTO(
+                    notificationId: notification.id,
+                    type: notification.type.rawValue,
+                    title: notification.title,
+                    message: notification.message,
+                    createdAt: ISO8601DateFormatter().string(from: notification.createdAt),
+                    isRead: notification.isRead,
+                    relatedId: notification.relatedId
+                )
+            }
+            
+            return NotificationListResponse(
+                notifications: mockNotifications,
+                hasNext: false,
+                totalCount: mockNotifications.count
+            )
+        }
+        
+        let path = "api/notifications?page=\(page)&size=\(size)"
+        
+        #if DEBUG
+        print("🔔 Fetching notifications: GET /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<APIResponse<NotificationListResponse>, APIClientError> = apiClient.request(
+            path: path,
+            method: .get,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            break
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard let data = response.data else {
+                            continuation.resume(throwing: APIClientError.decoding("Response data is nil", nil))
+                            return
+                        }
+                        continuation.resume(returning: data)
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Mark As Read
+    public func markAsRead(notificationIds: [String]) async throws -> Bool {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔔 Mock: Mark notifications as read: \(notificationIds)")
+            #endif
+            return true
+        }
+        
+        let path = "api/notifications/read"
+        let request = MarkNotificationReadRequest(notificationIds: notificationIds)
+        
+        #if DEBUG
+        print("🔔 Marking notifications as read: POST /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<APIResponse<MarkNotificationReadResponse>, APIClientError> = apiClient.request(
+            path: path,
+            method: .post,
+            body: request,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            break
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard let data = response.data else {
+                            continuation.resume(throwing: APIClientError.decoding("Response data is nil", nil))
+                            return
+                        }
+                        continuation.resume(returning: data.success)
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Delete Notifications
+    public func deleteNotifications(notificationIds: [String]) async throws -> Bool {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔔 Mock: Delete notifications: \(notificationIds)")
+            #endif
+            return true
+        }
+        
+        let path = "api/notifications"
+        let request = DeleteNotificationRequest(notificationIds: notificationIds)
+        
+        #if DEBUG
+        print("🔔 Deleting notifications: DELETE /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<APIResponse<DeleteNotificationResponse>, APIClientError> = apiClient.request(
+            path: path,
+            method: .delete,
+            body: request,
+            encoder: JSONParameterEncoder.default,
+            headers: APIClient.jsonHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            break
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard let data = response.data else {
+                            continuation.resume(throwing: APIClientError.decoding("Response data is nil", nil))
+                            return
+                        }
+                        continuation.resume(returning: data.success)
+                    }
+                )
+        }
+    }
+    
+    // MARK: - Delete All Notifications
+    public func deleteAllNotifications() async throws -> Bool {
+        if MockConfig.useMockData {
+            #if DEBUG
+            print("🔔 Mock: Delete all notifications")
+            #endif
+            return true
+        }
+        
+        let path = "api/notifications/all"
+        
+        #if DEBUG
+        print("🔔 Deleting all notifications: DELETE /\(path)")
+        #endif
+        
+        let publisher: AnyPublisher<APIResponse<DeleteAllNotificationsResponse>, APIClientError> = apiClient.request(
+            path: path,
+            method: .delete,
+            headers: APIClient.defaultHeaders,
+            interceptor: nil
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = publisher
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            break
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { response in
+                        guard let data = response.data else {
+                            continuation.resume(throwing: APIClientError.decoding("Response data is nil", nil))
+                            return
+                        }
+                        continuation.resume(returning: data.success)
+                    }
+                )
+        }
+    }
+}
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/Repositories/NotificationRepositoryProtocol.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/Repositories/NotificationRepositoryProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  NotificationRepositoryProtocol.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+import ModelsShared
+
+public protocol NotificationRepositoryProtocol {
+    /// 알림 목록 조회
+    func fetchNotifications(page: Int, size: Int) async throws -> NotificationListResponse
+    
+    /// 알림 읽음 처리
+    func markAsRead(notificationIds: [String]) async throws -> Bool
+    
+    /// 알림 삭제
+    func deleteNotifications(notificationIds: [String]) async throws -> Bool
+    
+    /// 전체 알림 삭제
+    func deleteAllNotifications() async throws -> Bool
+}
+
+
+
+
+
+
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/DeleteAllNotificationsUseCase.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/DeleteAllNotificationsUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteAllNotificationsUseCase.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+
+public final class DeleteAllNotificationsUseCase {
+    private let repository: NotificationRepositoryProtocol
+    
+    public init(repository: NotificationRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> Bool {
+        return try await repository.deleteAllNotifications()
+    }
+}
+
+
+
+
+
+
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/DeleteNotificationsUseCase.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/DeleteNotificationsUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteNotificationsUseCase.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+
+public final class DeleteNotificationsUseCase {
+    private let repository: NotificationRepositoryProtocol
+    
+    public init(repository: NotificationRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(notificationIds: [String]) async throws -> Bool {
+        return try await repository.deleteNotifications(notificationIds: notificationIds)
+    }
+}
+
+
+
+
+
+
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/FetchNotificationsUseCase.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/FetchNotificationsUseCase.swift
@@ -1,0 +1,48 @@
+//
+//  FetchNotificationsUseCase.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+import ModelsShared
+
+public final class FetchNotificationsUseCase {
+    private let repository: NotificationRepositoryProtocol
+    
+    public init(repository: NotificationRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(page: Int, size: Int = 20) async throws -> ([ModelsShared.Notification], Bool) {
+        let response = try await repository.fetchNotifications(page: page, size: size)
+        
+        // DTO를 Domain 모델로 변환
+        let notifications = response.notifications.compactMap { dto -> ModelsShared.Notification? in
+            guard let type = NotificationType(rawValue: dto.type),
+                  let createdAt = ISO8601DateFormatter().date(from: dto.createdAt) else {
+                return nil
+            }
+            
+            return ModelsShared.Notification(
+                id: dto.notificationId,
+                type: type,
+                title: dto.title,
+                message: dto.message,
+                createdAt: createdAt,
+                isRead: dto.isRead,
+                relatedId: dto.relatedId
+            )
+        }
+        
+        return (notifications, response.hasNext)
+    }
+}
+
+
+
+
+
+
+

--- a/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/MarkNotificationAsReadUseCase.swift
+++ b/beilsang/Projects/Domain/NotificationDomain/Sources/UseCases/MarkNotificationAsReadUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  MarkNotificationAsReadUseCase.swift
+//  NotificationDomain
+//
+//  Created by Park Seyoung on 12/18/25.
+//
+
+import Foundation
+
+public final class MarkNotificationAsReadUseCase {
+    private let repository: NotificationRepositoryProtocol
+    
+    public init(repository: NotificationRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    public func execute(notificationIds: [String]) async throws -> Bool {
+        return try await repository.markAsRead(notificationIds: notificationIds)
+    }
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
## 📋 관련 이슈
Closes #3

## 🎯 작업 내용
챌린지 및 알림 관련 Domain 레이어 구현 (앱의 핵심 비즈니스 로직)

## 🏗️ 주요 변경사항

### ChallengeDomain
- **Repository**: 
  - ChallengeQueryRepository (조회 전용)
  - ChallengeCommandRepository (생성/수정/삭제)
  - FeedRepository (피드 관련)
  - ChallengeRepositoryHelpers (공통 로직)
- **UseCase** (8개):
  - FetchChallengeListUseCase (필터링, 검색)
  - FetchChallengeDetailUseCase
  - FetchRecommendedChallengesUseCase
  - FetchActiveChallengesUseCase
  - CreateChallengeUseCase
  - JoinChallengeUseCase
  - CheckChallengeEnrollmentUseCase
  - FetchChallengeFeedThumbnailsUseCase
- **Mock**: MockChallengeData (개발/테스트용)

### NotificationDomain
- **Repository**: NotificationRepository
- **UseCase** (4개):
  - FetchNotificationsUseCase
  - MarkNotificationAsReadUseCase
  - DeleteNotificationsUseCase
  - DeleteAllNotificationsUseCase

## 💡 설계 특징
- **Command-Query 분리**: 조회/변경 로직 분리로 복잡도 감소
- **Protocol 기반 추상화**: 테스트 및 확장 용이
- **Mock 데이터 제공**: API 없이도 UI 개발 가능

## 🧪 테스트
- [x] 빌드 성공
- [x] 8개 Challenge UseCase 컴파일 확인
- [x] 4개 Notification UseCase 컴파일 확인
